### PR TITLE
Use pcall for threads

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,7 @@ export class Trove {
 		if (track.cleanup === FN_MARKER) {
 			(track.obj as () => void)();
 		} else if (track.cleanup === THREAD_MARKER) {
-			task.cancel(track.obj as thread);
+			pcall(task.cancel, track.obj as thread)
 		} else {
 			(track.obj as Record<string, (self: unknown) => void>)[track.cleanup](track.obj);
 		}


### PR DESCRIPTION
Adding threads to the trove throws an error if the thread expires, using pcall will silence the error caused by trying to do task.cancel on a finished thread.